### PR TITLE
Support fetching models from GitHub. Make cache expire.

### DIFF
--- a/.github/workflows/nrn-modeldb-ci.yaml
+++ b/.github/workflows/nrn-modeldb-ci.yaml
@@ -104,7 +104,7 @@ jobs:
         key: models
 
     - name: Get ModelDB models
-      if: steps.cache-models.outputs.cache-hit != 'true'
+      # if: steps.cache-models.outputs.cache-hit != 'true'
       run: getmodels
 
     - name: Run Models with NEURON V1 -> ${{ env.NEURON_V1 }}

--- a/.github/workflows/nrn-modeldb-ci.yaml
+++ b/.github/workflows/nrn-modeldb-ci.yaml
@@ -83,6 +83,7 @@ jobs:
       if: github.event_name == 'pull_request'
 
     - name: Install dependencies and project
+      id: install-deps
       run: |
         set
         # Set up Xvfb
@@ -93,15 +94,16 @@ jobs:
         if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
         #Install project in editable mode
         python -m pip install -e .
+        echo "::set-output name=date::$(date -u "+%Y%m")"
     
     - name: Cache ModelDB models
       id: cache-models
-      uses: actions/cache@v2
+      uses: actions/cache@v3
       with:
         path: |
           cache
           modeldb/modeldb-meta.yaml
-        key: models
+        key: models-${{steps.install-deps.outputs.date}}
 
     - name: Get ModelDB models
       # if: steps.cache-models.outputs.cache-hit != 'true'

--- a/.github/workflows/nrn-modeldb-ci.yaml
+++ b/.github/workflows/nrn-modeldb-ci.yaml
@@ -106,7 +106,7 @@ jobs:
         key: models-${{steps.install-deps.outputs.date}}
 
     - name: Get ModelDB models
-      # if: steps.cache-models.outputs.cache-hit != 'true'
+      if: steps.cache-models.outputs.cache-hit != 'true'
       run: getmodels
 
     - name: Run Models with NEURON V1 -> ${{ env.NEURON_V1 }}

--- a/modeldb/modeldb-run.yaml
+++ b/modeldb/modeldb-run.yaml
@@ -752,6 +752,7 @@
     - run()
     - verify_graph_()
 113732:
+    github: 'pull/1'
     run:
     - use_mcell_ran4(1)
     - suprathresh()

--- a/modeldb/modeldb-run.yaml
+++ b/modeldb/modeldb-run.yaml
@@ -705,10 +705,6 @@
     run:
     - load_file("batch_.hoc")
     - verify_graph_()
-    script:
-    - sed 's/batch_flag=0/batch_flag=1/
-    - s/tstop = 1e3/tstop = 20/' batch_.hoc > temp.tmp
-    - mv temp.tmp batch_.hoc
 106551:
     run:
     - use_mcell_ran4(1)

--- a/modeldb/modeldb-run.yaml
+++ b/modeldb/modeldb-run.yaml
@@ -858,6 +858,7 @@
     - run()
     - verify_graph_()
 116838:
+    github: 'pull/1'
     run:
     - tstop=10
     - run()

--- a/modeldb/modeldb-run.yaml
+++ b/modeldb/modeldb-run.yaml
@@ -1064,6 +1064,8 @@
     - verify_graph_()
 144538:
     github: 'pull/1'
+144549:
+    github: 'pull/1'
 144586:
     github: 'pull/1'
 145836:

--- a/modeldb/modeldb-run.yaml
+++ b/modeldb/modeldb-run.yaml
@@ -1004,6 +1004,8 @@
     github: 'pull/1'
 136310:
     github: 'pull/1'
+137845:
+    github: 'pull/1'
 138321:
     run:
     - run()
@@ -1110,6 +1112,8 @@
         archive
     run: null
 181967:
+    github: 'pull/1'
+182129:
     github: 'pull/1'
 185355:
     github: 'pull/2'

--- a/modeldb/modeldb-run.yaml
+++ b/modeldb/modeldb-run.yaml
@@ -216,6 +216,7 @@
     - dend_inj()
     - verify_graph_()
 8284:
+    github: 'pull/1'
     run:
     - run()
     - verify_graph_()

--- a/modeldb/modeldb-run.yaml
+++ b/modeldb/modeldb-run.yaml
@@ -565,12 +565,15 @@
 239177:
     github: 'pull/1'
 241165:
+    github: 'pull/1'
     model_dir: mechanisms
     run:
     - tstop = 300 # original tstop is 30000 , too big
     - run()
     - verify_graph_()
 241240:
+    github: 'pull/1'
+247968:
     github: 'pull/1'
 260971:
     comment: tricky to set-up due to mosinit.hoc autodiscovery
@@ -992,6 +995,8 @@
     - mv temp.tmp MOPP_Fig_1B_left/ichan2.mod
 136095:
     github: 'pull/1'
+136310:
+    github: 'pull/1'
 138321:
     run:
     - run()
@@ -1077,6 +1082,8 @@
 150284:
     comment: //do not run Mattione Le Novere missing _run_me.hoc in parallel model
     run: null
+150556:
+    github: 'pull/1'
 153280:
     github: 'pull/1'
 154732:

--- a/modeldb/modeldb-run.yaml
+++ b/modeldb/modeldb-run.yaml
@@ -202,6 +202,10 @@
     run:
     - runc()
     - verify_graph_()
+7399:
+    github: 'pull/1'
+7400:
+    github: 'pull/1'
 7659:
     run:
     - runp()
@@ -332,6 +336,7 @@
     comment: //disregard cannot be run in batch mode
     skip: true
 26997:
+    github: 'pull/1'
     run:
     - fig1a()
     - verify_graph_()
@@ -347,6 +352,8 @@
     - ringperf()
     - run()
     - verify_graph_()
+37819:
+    github: 'pull/1'
 37856:
     run:
     - runiv()
@@ -1039,6 +1046,8 @@
     - init()
     - run()
     - verify_graph_()
+144538:
+    github: 'pull/1'
 144586:
     github: 'pull/1'
 145836:

--- a/modeldb/modeldb-run.yaml
+++ b/modeldb/modeldb-run.yaml
@@ -715,7 +715,7 @@
     - run()
     - verify_graph_()
 106891:
-    github: 'pull/1'
+    github: 'pull/3'
     run:
     - tstop=10
     - runeg()

--- a/modeldb/modeldb-run.yaml
+++ b/modeldb/modeldb-run.yaml
@@ -713,6 +713,7 @@
     - run()
     - verify_graph_()
 106891:
+    github: 'pull/1'
     run:
     - tstop=10
     - runeg()

--- a/modeldb/modeldb-run.yaml
+++ b/modeldb/modeldb-run.yaml
@@ -1113,6 +1113,8 @@
     github: 'pull/1'
 150691:
     github: 'pull/1'
+151282:
+    github: 'pull/1'
 153280:
     github: 'pull/1'
 154732:

--- a/modeldb/modeldb-run.yaml
+++ b/modeldb/modeldb-run.yaml
@@ -1171,6 +1171,11 @@
 149174:
     skip: true
     comment: testing in Python + hardcoded NEURON
+244262:
+    github: 'pull/1'
+    script:
+    - if [[ ! -f Iintra.dat ]]; then unzip Iintra.dat.zip; fi
+    - ls -l Iintra.dat
 258867:
     run:
     - run()

--- a/modeldb/modeldb-run.yaml
+++ b/modeldb/modeldb-run.yaml
@@ -1030,6 +1030,7 @@
     comment: //do not run
     run: null
 140881:
+    github: 'pull/1'
     comment: //do not run Lytton model takes too long to run and complex to edit
     run: null
 141063:
@@ -1129,6 +1130,10 @@
     github: 'pull/1'
 185355:
     github: 'pull/2'
+185858:
+    github: 'pull/1'
+186768:
+    github: 'pull/1'
 187604:
   curate_patterns:
     - pattern: 'TIME HOST 0: [0-9\.]+ seconds \(set up\)'

--- a/modeldb/modeldb-run.yaml
+++ b/modeldb/modeldb-run.yaml
@@ -672,7 +672,7 @@
     model_dir: modeldb
     run:
     - verify_graph_()
-    github: 'pull/1'
+    github: 'pull/2'
 97917:
     run:
     - traub_launch()

--- a/modeldb/modeldb-run.yaml
+++ b/modeldb/modeldb-run.yaml
@@ -1095,14 +1095,13 @@
     curate_patterns:
       - pattern: 't=100\.00;122\([0-9]+\.[0-9]+\)'
         repl: 't=100.00;122(%some_kind_of_clock%)'
+    github: 'pull/1'
     run:
     - tstop=100
     - init()
     - run()
     - verify_graph_()
 150240:
-    github: 'pull/1'
-150245:
     github: 'pull/1'
 150284:
     comment: //do not run Mattione Le Novere missing _run_me.hoc in parallel model

--- a/modeldb/modeldb-run.yaml
+++ b/modeldb/modeldb-run.yaml
@@ -1111,6 +1111,8 @@
 223962:
     skip: true
     comment: takes too long, need to see how to reduce time
+225080:
+    github: 'pull/1'
 149174:
     skip: true
     comment: testing in Python + hardcoded NEURON

--- a/modeldb/modeldb-run.yaml
+++ b/modeldb/modeldb-run.yaml
@@ -674,6 +674,7 @@
     - verify_graph_()
     github: 'pull/2'
 97917:
+    github: 'pull/2'
     run:
     - traub_launch()
     - verify_graph_()

--- a/modeldb/modeldb-run.yaml
+++ b/modeldb/modeldb-run.yaml
@@ -1129,6 +1129,8 @@
     comment: //do not run Tried "initDialog.unmap(1)" - didnt work.  Need to change
         archive
     run: null
+168874:
+    github: 'pull/4'
 181967:
     github: 'pull/1'
 182129:

--- a/modeldb/modeldb-run.yaml
+++ b/modeldb/modeldb-run.yaml
@@ -104,6 +104,7 @@
     - run()
     - verify_graph_()
 3658:
+    github: 'pull/1'
     run:
     - glubes2D()
     - run()
@@ -229,6 +230,8 @@
     - use_mcell_ran4(1)
     - rund()
     - verify_graph_()
+9889:
+    github: 'pull/1'
 12631:
     github: default
 17663:
@@ -562,7 +565,7 @@
     - run()
     - verify_graph_()
 231427:
-    github: 'default'
+    github: 'pull/2'
 235769:
     model_dir: fig3
     run:
@@ -667,6 +670,7 @@
     model_dir: modeldb
     run:
     - verify_graph_()
+    github: 'pull/1'
 97917:
     run:
     - traub_launch()
@@ -694,6 +698,7 @@
     - run()
     - verify_graph_()
 105507:
+    github: 'pull/2'
     run:
     - load_file("batch_.hoc")
     - verify_graph_()
@@ -866,6 +871,8 @@
     script:
     - sed 's/^showdemo=1/showdemo=0/' mosinit.hoc > temp.tmp
     - mv temp.tmp mosinit.hoc
+116862:
+    github: 'pull/1'
 116956:
     run:
     - run()
@@ -1094,7 +1101,11 @@
 150284:
     comment: //do not run Mattione Le Novere missing _run_me.hoc in parallel model
     run: null
+150551:
+    github: 'pull/1'
 150556:
+    github: 'pull/1'
+150691:
     github: 'pull/1'
 153280:
     github: 'pull/1'
@@ -1147,7 +1158,10 @@
     script:
     - sed -i 's/tstop = /tstop = 50\/\//' Fig8_tuft_NMDA_spike.hoc
     - sed -i 's/simul_iter=/simul_iter=2 \/\//' Fig8_tuft_NMDA_spike.hoc
-    comment: usual simulation time is ~ 10 minutes (tstop = 120 and simul_iter=10)
+    comment: usual simulation time is ~ 10 minutes (tstop = 120 and
+    simul_iter=10)
+259366:
+    github: 'pull/1'
 206267:
     run:
     - run()

--- a/modeldb/modeldb-run.yaml
+++ b/modeldb/modeldb-run.yaml
@@ -1158,8 +1158,7 @@
     script:
     - sed -i 's/tstop = /tstop = 50\/\//' Fig8_tuft_NMDA_spike.hoc
     - sed -i 's/simul_iter=/simul_iter=2 \/\//' Fig8_tuft_NMDA_spike.hoc
-    comment: usual simulation time is ~ 10 minutes (tstop = 120 and
-    simul_iter=10)
+    comment: usual simulation time is ~ 10 minutes (tstop = 120 and simul_iter=10)
 259366:
     github: 'pull/1'
 206267:

--- a/modeldb/modeldb-run.yaml
+++ b/modeldb/modeldb-run.yaml
@@ -1146,6 +1146,8 @@
     - pattern: 'TIME HOST 0: [0-9\.]+ seconds \(created cells\)'
       repl: 'TIME HOST 0: %elapsed_time% seconds (created cells)'
   github: 'pull/2'
+189154:
+    github: 'pull/1'
 194897:
     github: 'pull/1'
 195615:

--- a/modeldb/modeldb-run.yaml
+++ b/modeldb/modeldb-run.yaml
@@ -225,6 +225,8 @@
     - use_mcell_ran4(1)
     - rund()
     - verify_graph_()
+12631:
+    github: default
 17663:
     run:
     - restart("re1_cc")
@@ -378,10 +380,12 @@
     - run()
     - verify_graph_()
 51781:
+    github: 'pull/1'
     run:
     - load_file("testnet.hoc")
     - verify_graph_()
 52034:
+    github: 'pull/1'
     run:
     - run_short()
     - verify_graph_()
@@ -523,6 +527,8 @@
     - tstop=1000
     - run()
     - verify_graph_()
+87585:
+    github: 'pull/1'
 156120:
     model_dir: mods/other_mods;mods/synapse
     run:
@@ -543,22 +549,29 @@
     - run()
     - verify_graph_()
 223031:
+    github: 'pull/1'
     model_dir: S1
     run:
     - run()
     - verify_graph_()
+231427:
+    github: 'default'
 235769:
     model_dir: fig3
     run:
     - tstop = 1000
     - run()
     - verify_graph_()
+239177:
+    github: 'pull/1'
 241165:
     model_dir: mechanisms
     run:
     - tstop = 300 # original tstop is 30000 , too big
     - run()
     - verify_graph_()
+241240:
+    github: 'pull/1'
 260971:
     comment: tricky to set-up due to mosinit.hoc autodiscovery
     skip: true
@@ -637,6 +650,7 @@
     - run()
     - verify_graph_()
 97868:
+    github: 'default'
     comment: //do not run
     run: null
 97874:
@@ -819,6 +833,7 @@
     - '{init() run()}'
     - verify_graph_()
 116830:
+    github: 'pull/1'
     run:
     - // takes too long and no gout data
     - //load_file("init.hoc")
@@ -940,6 +955,7 @@
     - run()
     - verify_graph_()
 123815:
+    github: 'pull/1'
     run:
     - tstop=5
     - newPlotV()
@@ -973,12 +989,15 @@
     script: # todo -> fix model for NEURON 8.0.0 and remove this script
     - sed 's/return 0;//' MOPP_Fig_1B_left/ichan2.mod > temp.tmp
     - mv temp.tmp MOPP_Fig_1B_left/ichan2.mod
+136095:
+    github: 'pull/1'
 138321:
     run:
     - run()
     - verify_graph_()
     model_dir: OneDimension/Neuron
 138379:
+    github: 'pull/1'
     run:
     - mytstop=0.1e3
     - tstop=mytstop
@@ -1000,6 +1019,7 @@
     run: null
 141505:
     comment: //do not run Specialized installation environment
+    github: 'pull/1'
     run: null
 144385:
   model_dir: mod
@@ -1013,6 +1033,8 @@
     - init()
     - run()
     - verify_graph_()
+144586:
+    github: 'pull/1'
 145836:
     run:
     - ParmFitnessGui[0].run()
@@ -1027,9 +1049,13 @@
         repl: 'Finished simulation in %simulation_time% seconds'
       - pattern: 'Current time: \d+/\d+/\d+,\d+:\d+:\d+ [AP]{1}M:\d+'
         repl: 'Current time: %current_time%'
+146949:
+    github: 'pull/1'
 147461:
     comment: //do not run Minimum time would be 1/2 hr default time is about 8.3 hours
     run: null
+149000:
+    github: 'default'
 149739:
     run:
     - demo_run()
@@ -1043,13 +1069,33 @@
     - init()
     - run()
     - verify_graph_()
+150240:
+    github: 'pull/1'
+150245:
+    github: 'pull/1'
 150284:
     comment: //do not run Mattione Le Novere missing _run_me.hoc in parallel model
     run: null
+153280:
+    github: 'pull/1'
+154732:
+    github: 'pull/1'
+155568:
+    github: 'pull/1'
+155601:
+    github: 'pull/1'
+155602:
+    github: 'pull/1'
+156780:
+    github: 'pull/1'
 167772:
     comment: //do not run Tried "initDialog.unmap(1)" - didnt work.  Need to change
         archive
     run: null
+181967:
+    github: 'pull/1'
+185355:
+    github: 'pull/2'
 187604:
   curate_patterns:
     - pattern: 'TIME HOST 0: [0-9\.]+ seconds \(set up\)'
@@ -1083,12 +1129,14 @@
     script:
     - sed -i 's/tstop=/tstop=100 \/\//' Start.hoc
 157157:
+    github: 'pull/1'
     run:
     - run()
     - verify_graph_()
     script:
     - sed -i 's/tstop = 5000/tstop = 250 \/\//g' PC.ses
 244848:
+    github: 'pull/2'
     run: null
     comment: not straightforward to cut down simulation time, takes too long
 #    run:
@@ -1105,7 +1153,12 @@
     - sed -i 's/500/5/g' BPF.hoc
     - sed -i 's/2\([0|1]\)000/2\1/g' BPF.hoc
     comment: diving some numbers with 100 halvened the sim time
+249463:
+    github: 'pull/1'
+256388:
+    github: 'pull/1'
 151126:
+    github: 'pull/1'
     run:
     - run()
     - verify_graph_()

--- a/modeldb/modeldb-run.yaml
+++ b/modeldb/modeldb-run.yaml
@@ -4,12 +4,16 @@
     - run()
     - verify_graph_()
 2487:
+    github: 'pull/1'
     run:
     - run()
     - verify_graph_()
 2730:
+    github: 'pull/1'
     run:
     - //launch but do not run
+2733:
+    github: 'pull/1'
 2796:
     run:
     - run()
@@ -457,6 +461,7 @@
     - run()
     - verify_graph_()
 64229:
+    github: 'pull/1'
     model_dir: parbulbNet
     run:
     - run()
@@ -470,6 +475,7 @@
     comment: //do not run takes too long
     run: null
 64296:
+    github: 'pull/1'
     run:
     - fig7A()
     - verify_graph_()
@@ -618,6 +624,7 @@
     - run()
     - verify_graph_()
 93321:
+    github: 'pull/1'
     run:
     - fig3topleft()
     - verify_graph_()
@@ -822,6 +829,7 @@
     - makeplusplus()
     - verify_graph_()
 116094:
+    github: 'pull/1'
     run:
     - load_file("mosinit.hoc")
     - run_experiment("fig2ace")
@@ -1087,6 +1095,7 @@
 149000:
     github: 'default'
 149739:
+    github: 'pull/1'
     run:
     - demo_run()
     - verify_graph_()
@@ -1135,6 +1144,8 @@
     github: 'pull/1'
 182129:
     github: 'pull/1'
+183300:
+    github: 'pull/1'
 185355:
     github: 'pull/2'
 185858:
@@ -1151,7 +1162,7 @@
 189154:
     github: 'pull/1'
 194897:
-    github: 'pull/1'
+    github: 'pull/2'
 195615:
     github: 'pull/1'
 206244:
@@ -1164,6 +1175,8 @@
     skip: true
     comment: takes too long, need to see how to reduce time
 225080:
+    github: 'pull/1'
+232097:
     github: 'pull/1'
 149174:
     skip: true

--- a/modeldb/modeldb-run.yaml
+++ b/modeldb/modeldb-run.yaml
@@ -4,16 +4,12 @@
     - run()
     - verify_graph_()
 2487:
-    github: 'pull/1'
     run:
     - run()
     - verify_graph_()
 2730:
-    github: 'pull/1'
     run:
     - //launch but do not run
-2733:
-    github: 'pull/1'
 2796:
     run:
     - run()
@@ -108,7 +104,6 @@
     - run()
     - verify_graph_()
 3658:
-    github: 'pull/1'
     run:
     - glubes2D()
     - run()
@@ -207,10 +202,6 @@
     run:
     - runc()
     - verify_graph_()
-7399:
-    github: 'pull/1'
-7400:
-    github: 'pull/1'
 7659:
     run:
     - runp()
@@ -225,7 +216,6 @@
     - dend_inj()
     - verify_graph_()
 8284:
-    github: 'pull/1'
     run:
     - run()
     - verify_graph_()
@@ -234,10 +224,6 @@
     - use_mcell_ran4(1)
     - rund()
     - verify_graph_()
-9889:
-    github: 'pull/1'
-12631:
-    github: 'pull/2'
 17663:
     run:
     - restart("re1_cc")
@@ -343,7 +329,6 @@
     comment: //disregard cannot be run in batch mode
     skip: true
 26997:
-    github: 'pull/1'
     run:
     - fig1a()
     - verify_graph_()
@@ -359,10 +344,6 @@
     - ringperf()
     - run()
     - verify_graph_()
-35358:
-    github: 'pull/2'
-37819:
-    github: 'pull/1'
 37856:
     run:
     - runiv()
@@ -396,12 +377,10 @@
     - run()
     - verify_graph_()
 51781:
-    github: 'pull/1'
     run:
     - load_file("testnet.hoc")
     - verify_graph_()
 52034:
-    github: 'pull/1'
     run:
     - run_short()
     - verify_graph_()
@@ -461,7 +440,6 @@
     - run()
     - verify_graph_()
 64229:
-    github: 'pull/1'
     model_dir: parbulbNet
     run:
     - run()
@@ -475,7 +453,6 @@
     comment: //do not run takes too long
     run: null
 64296:
-    github: 'pull/1'
     run:
     - fig7A()
     - verify_graph_()
@@ -545,8 +522,6 @@
     - tstop=1000
     - run()
     - verify_graph_()
-87585:
-    github: 'pull/1'
 156120:
     model_dir: mods/other_mods;mods/synapse
     run:
@@ -567,32 +542,22 @@
     - run()
     - verify_graph_()
 223031:
-    github: 'pull/1'
     model_dir: S1
     run:
     - run()
     - verify_graph_()
-231427:
-    github: 'pull/2'
 235769:
     model_dir: fig3
     run:
     - tstop = 1000
     - run()
     - verify_graph_()
-239177:
-    github: 'pull/1'
 241165:
-    github: 'pull/1'
     model_dir: mechanisms
     run:
     - tstop = 300 # original tstop is 30000 , too big
     - run()
     - verify_graph_()
-241240:
-    github: 'pull/1'
-247968:
-    github: 'pull/1'
 260971:
     comment: tricky to set-up due to mosinit.hoc autodiscovery
     skip: true
@@ -624,7 +589,6 @@
     - run()
     - verify_graph_()
 93321:
-    github: 'pull/1'
     run:
     - fig3topleft()
     - verify_graph_()
@@ -672,14 +636,12 @@
     - run()
     - verify_graph_()
 97868:
-    github: 'pull/2'
     comment: //do not run
     run: null
 97874:
     model_dir: modeldb
     run:
     - verify_graph_()
-    github: 'pull/2'
 97917:
     github: 'pull/2'
     run:
@@ -712,6 +674,10 @@
     run:
     - load_file("batch_.hoc")
     - verify_graph_()
+    script:
+    - sed 's/batch_flag=0/batch_flag=1/
+    - s/tstop = 1e3/tstop = 20/' batch_.hoc > temp.tmp
+    - mv temp.tmp batch_.hoc
 106551:
     run:
     - use_mcell_ran4(1)
@@ -719,7 +685,6 @@
     - run()
     - verify_graph_()
 106891:
-    github: 'pull/3'
     run:
     - tstop=10
     - runeg()
@@ -774,7 +739,6 @@
     - run()
     - verify_graph_()
 113732:
-    github: 'pull/1'
     run:
     - use_mcell_ran4(1)
     - suprathresh()
@@ -829,7 +793,6 @@
     - makeplusplus()
     - verify_graph_()
 116094:
-    github: 'pull/1'
     run:
     - load_file("mosinit.hoc")
     - run_experiment("fig2ace")
@@ -857,7 +820,6 @@
     - '{init() run()}'
     - verify_graph_()
 116830:
-    github: 'pull/1'
     run:
     - // takes too long and no gout data
     - //load_file("init.hoc")
@@ -871,7 +833,6 @@
     - run()
     - verify_graph_()
 116838:
-    github: 'pull/1'
     run:
     - tstop=10
     - run()
@@ -879,8 +840,6 @@
     script:
     - sed 's/^showdemo=1/showdemo=0/' mosinit.hoc > temp.tmp
     - mv temp.tmp mosinit.hoc
-116862:
-    github: 'pull/1'
 116956:
     run:
     - run()
@@ -982,7 +941,6 @@
     - run()
     - verify_graph_()
 123815:
-    github: 'pull/1'
     run:
     - tstop=5
     - newPlotV()
@@ -1016,10 +974,6 @@
     script: # todo -> fix model for NEURON 8.0.0 and remove this script
     - sed 's/return 0;//' MOPP_Fig_1B_left/ichan2.mod > temp.tmp
     - mv temp.tmp MOPP_Fig_1B_left/ichan2.mod
-136095:
-    github: 'pull/1'
-136310:
-    github: 'pull/1'
 137845:
     github: 'pull/1'
 138321:
@@ -1028,20 +982,17 @@
     - verify_graph_()
     model_dir: OneDimension/Neuron
 138379:
-    github: 'pull/1'
     run:
     - mytstop=0.1e3
     - tstop=mytstop
     - finish_run()
     - verify_graph_()
-139421:
-    github: 'pull/1'
 139656:
     comment: //do not run
     run: null
 140881:
-    github: 'pull/1'
     comment: //do not run Lytton model takes too long to run and complex to edit
+    github: 'pull/1'
     run: null
 141063:
     comment: //do not run Problem is that Vbox.dialog() steals the focus (complex
@@ -1067,12 +1018,6 @@
     - init()
     - run()
     - verify_graph_()
-144538:
-    github: 'pull/1'
-144549:
-    github: 'pull/1'
-144586:
-    github: 'pull/1'
 145836:
     run:
     - ParmFitnessGui[0].run()
@@ -1087,15 +1032,10 @@
         repl: 'Finished simulation in %simulation_time% seconds'
       - pattern: 'Current time: \d+/\d+/\d+,\d+:\d+:\d+ [AP]{1}M:\d+'
         repl: 'Current time: %current_time%'
-146949:
-    github: 'pull/1'
 147461:
     comment: //do not run Minimum time would be 1/2 hr default time is about 8.3 hours
     run: null
-149000:
-    github: 'default'
 149739:
-    github: 'pull/1'
     run:
     - demo_run()
     - verify_graph_()
@@ -1103,68 +1043,26 @@
     curate_patterns:
       - pattern: 't=100\.00;122\([0-9]+\.[0-9]+\)'
         repl: 't=100.00;122(%some_kind_of_clock%)'
-    github: 'pull/1'
     run:
     - tstop=100
     - init()
     - run()
     - verify_graph_()
-150240:
-    github: 'pull/1'
 150284:
     comment: //do not run Mattione Le Novere missing _run_me.hoc in parallel model
     run: null
-150551:
-    github: 'pull/1'
-150556:
-    github: 'pull/1'
-150691:
-    github: 'pull/1'
-151282:
-    github: 'pull/1'
-153280:
-    github: 'pull/1'
-154732:
-    github: 'pull/1'
-155568:
-    github: 'pull/1'
-155601:
-    github: 'pull/1'
-155602:
-    github: 'pull/1'
-156780:
-    github: 'pull/1'
 167772:
     comment: //do not run Tried "initDialog.unmap(1)" - didnt work.  Need to change
         archive
     run: null
-168874:
-    github: 'pull/4'
-181967:
-    github: 'pull/1'
-182129:
-    github: 'pull/1'
-183300:
-    github: 'pull/1'
-185355:
-    github: 'pull/2'
-185858:
-    github: 'pull/1'
-186768:
-    github: 'pull/1'
 187604:
   curate_patterns:
     - pattern: 'TIME HOST 0: [0-9\.]+ seconds \(set up\)'
       repl: 'TIME HOST 0: %elapsed_time% seconds (set up)'
     - pattern: 'TIME HOST 0: [0-9\.]+ seconds \(created cells\)'
       repl: 'TIME HOST 0: %elapsed_time% seconds (created cells)'
-  github: 'pull/2'
-189154:
-    github: 'pull/1'
 194897:
     github: 'pull/2'
-195615:
-    github: 'pull/1'
 206244:
     run:
     - chdir("mechanism")
@@ -1174,18 +1072,13 @@
 223962:
     skip: true
     comment: takes too long, need to see how to reduce time
-225080:
-    github: 'pull/1'
-232097:
-    github: 'pull/1'
-149174:
-    skip: true
-    comment: testing in Python + hardcoded NEURON
 244262:
-    github: 'pull/1'
     script:
     - if [[ ! -f Iintra.dat ]]; then unzip Iintra.dat.zip; fi
     - ls -l Iintra.dat
+149174:
+    skip: true
+    comment: testing in Python + hardcoded NEURON
 258867:
     run:
     - run()
@@ -1194,8 +1087,6 @@
     - sed -i 's/tstop = /tstop = 50\/\//' Fig8_tuft_NMDA_spike.hoc
     - sed -i 's/simul_iter=/simul_iter=2 \/\//' Fig8_tuft_NMDA_spike.hoc
     comment: usual simulation time is ~ 10 minutes (tstop = 120 and simul_iter=10)
-259366:
-    github: 'pull/1'
 206267:
     run:
     - run()
@@ -1203,14 +1094,12 @@
     script:
     - sed -i 's/tstop=/tstop=100 \/\//' Start.hoc
 157157:
-    github: 'pull/1'
     run:
     - run()
     - verify_graph_()
     script:
     - sed -i 's/tstop = 5000/tstop = 250 \/\//g' PC.ses
 244848:
-    github: 'pull/2'
     run: null
     comment: not straightforward to cut down simulation time, takes too long
 #    run:
@@ -1227,12 +1116,7 @@
     - sed -i 's/500/5/g' BPF.hoc
     - sed -i 's/2\([0|1]\)000/2\1/g' BPF.hoc
     comment: diving some numbers with 100 halvened the sim time
-249463:
-    github: 'pull/1'
-256388:
-    github: 'pull/1'
 151126:
-    github: 'pull/1'
     run:
     - run()
     - verify_graph_()

--- a/modeldb/modeldb-run.yaml
+++ b/modeldb/modeldb-run.yaml
@@ -1029,6 +1029,8 @@
     - tstop=mytstop
     - finish_run()
     - verify_graph_()
+139421:
+    github: 'pull/1'
 139656:
     comment: //do not run
     run: null

--- a/modeldb/modeldb-run.yaml
+++ b/modeldb/modeldb-run.yaml
@@ -643,7 +643,6 @@
     run:
     - verify_graph_()
 97917:
-    github: 'pull/2'
     run:
     - traub_launch()
     - verify_graph_()
@@ -670,7 +669,6 @@
     - run()
     - verify_graph_()
 105507:
-    github: 'pull/2'
     run:
     - load_file("batch_.hoc")
     - verify_graph_()
@@ -974,8 +972,6 @@
     script: # todo -> fix model for NEURON 8.0.0 and remove this script
     - sed 's/return 0;//' MOPP_Fig_1B_left/ichan2.mod > temp.tmp
     - mv temp.tmp MOPP_Fig_1B_left/ichan2.mod
-137845:
-    github: 'pull/1'
 138321:
     run:
     - run()
@@ -992,7 +988,6 @@
     run: null
 140881:
     comment: //do not run Lytton model takes too long to run and complex to edit
-    github: 'pull/1'
     run: null
 141063:
     comment: //do not run Problem is that Vbox.dialog() steals the focus (complex
@@ -1004,7 +999,6 @@
     run: null
 141505:
     comment: //do not run Specialized installation environment
-    github: 'pull/1'
     run: null
 144385:
   model_dir: mod
@@ -1061,8 +1055,6 @@
       repl: 'TIME HOST 0: %elapsed_time% seconds (set up)'
     - pattern: 'TIME HOST 0: [0-9\.]+ seconds \(created cells\)'
       repl: 'TIME HOST 0: %elapsed_time% seconds (created cells)'
-194897:
-    github: 'pull/2'
 206244:
     run:
     - chdir("mechanism")

--- a/modeldb/modeldb-run.yaml
+++ b/modeldb/modeldb-run.yaml
@@ -233,7 +233,7 @@
 9889:
     github: 'pull/1'
 12631:
-    github: default
+    github: 'pull/2'
 17663:
     run:
     - restart("re1_cc")

--- a/modeldb/modeldb-run.yaml
+++ b/modeldb/modeldb-run.yaml
@@ -665,7 +665,7 @@
     - run()
     - verify_graph_()
 97868:
-    github: 'default'
+    github: 'pull/2'
     comment: //do not run
     run: null
 97874:

--- a/modeldb/modeldb-run.yaml
+++ b/modeldb/modeldb-run.yaml
@@ -355,6 +355,8 @@
     - ringperf()
     - run()
     - verify_graph_()
+35358:
+    github: 'pull/2'
 37819:
     github: 'pull/1'
 37856:
@@ -1141,7 +1143,10 @@
       repl: 'TIME HOST 0: %elapsed_time% seconds (set up)'
     - pattern: 'TIME HOST 0: [0-9\.]+ seconds \(created cells\)'
       repl: 'TIME HOST 0: %elapsed_time% seconds (created cells)'
+  github: 'pull/2'
 194897:
+    github: 'pull/1'
+195615:
     github: 'pull/1'
 206244:
     run:

--- a/modeldb/modeldb-run.yaml
+++ b/modeldb/modeldb-run.yaml
@@ -1103,6 +1103,8 @@
       repl: 'TIME HOST 0: %elapsed_time% seconds (set up)'
     - pattern: 'TIME HOST 0: [0-9\.]+ seconds \(created cells\)'
       repl: 'TIME HOST 0: %elapsed_time% seconds (created cells)'
+194897:
+    github: 'pull/1'
 206244:
     run:
     - chdir("mechanism")

--- a/modeldb/modeldb.py
+++ b/modeldb/modeldb.py
@@ -33,19 +33,21 @@ def download_model(arg_tuple):
         with open(model_zip_uri, "wb+") as zipfile:
             zipfile.write(base64.standard_b64decode(url["file_content"]))
 
-        if 'github' in model_run_info:
+        if "github" in model_run_info:
             # This means we should try to replace the version of the model that
             # we downloaded from the ModelDB API just above with a version from
             # GitHub
-            github = model_run_info['github']
-            if github == 'default':
-                suffix = ''
-            elif github.startswith('pull/'):
+            github = model_run_info["github"]
+            if github == "default":
+                suffix = ""
+            elif github.startswith("pull/"):
                 pr_number = int(github[5:])
-                suffix = '/pull/{}/head'.format(pr_number)
+                suffix = "/pull/{}/head".format(pr_number)
             else:
                 raise Exception("Invalid value for github key: {}".format(github))
-            github_url = 'https://api.github.com/repos/ModelDBRepository/{model_id}/zipball{suffix}'.format(model_id=model_id, suffix=suffix)
+            github_url = "https://api.github.com/repos/ModelDBRepository/{model_id}/zipball{suffix}".format(
+                model_id=model_id, suffix=suffix
+            )
             # Replace the local file `model_zip_uri` with the zip file we
             # downloaded from `github_url`
             github_response = requests.get(github_url)
@@ -85,7 +87,10 @@ class ModelDB(object):
             os.mkdir(MODELS_ZIP_DIR)
         models = requests.get(MDB_NEURON_MODELS_URL).json() if model_list is None else model_list
         pool = multiprocessing.Pool()
-        processed_models = pool.imap_unordered(download_model, [(model_id, self._run_instr[model_id]) for model_id in models])
+        processed_models = pool.imap_unordered(
+            download_model,
+            [(model_id, self._run_instr[model_id]) for model_id in models],
+        )
         download_err = {}
         for model_id, model in ProgressBar.iter(processed_models, len(models)):
             if not isinstance(model, Exception):

--- a/modeldb/modeldb.py
+++ b/modeldb/modeldb.py
@@ -11,7 +11,8 @@ from .config import *
 import traceback
 from pprint import pformat
 
-def download_model(model_id):
+def download_model(arg_tuple):
+    model_id, model_run_info = arg_tuple
     try:
         model_json = requests.get(MDB_MODEL_DOWNLOAD_URL.format(model_id=model_id)).json()
         model = Model(
@@ -31,6 +32,26 @@ def download_model(model_id):
         )
         with open(model_zip_uri, "wb+") as zipfile:
             zipfile.write(base64.standard_b64decode(url["file_content"]))
+
+        if 'github' in model_run_info:
+            # This means we should try to replace the version of the model that
+            # we downloaded from the ModelDB API just above with a version from
+            # GitHub
+            github = model_run_info['github']
+            if github == 'default':
+                suffix = ''
+            elif github.startswith('pull/'):
+                pr_number = int(github[5:])
+                suffix = '/pull/{}/head'.format(pr_number)
+            else:
+                raise Exception("Invalid value for github key: {}".format(github))
+            github_url = 'https://api.github.com/repos/ModelDBRepository/{model_id}/zipball{suffix}'.format(model_id=model_id, suffix=suffix)
+            # Replace the local file `model_zip_uri` with the zip file we
+            # downloaded from `github_url`
+            github_response = requests.get(github_url)
+            assert github_response.status_code == requests.codes.ok
+            with open(model_zip_uri, "wb+") as zipfile:
+                zipfile.write(github_response.content)
     except Exception as e:   #  noqa
         model = e
 
@@ -64,7 +85,7 @@ class ModelDB(object):
             os.mkdir(MODELS_ZIP_DIR)
         models = requests.get(MDB_NEURON_MODELS_URL).json() if model_list is None else model_list
         pool = multiprocessing.Pool()
-        processed_models = pool.imap_unordered(download_model, models)
+        processed_models = pool.imap_unordered(download_model, [(model_id, self._run_instr[model_id]) for model_id in models])
         download_err = {}
         for model_id, model in ProgressBar.iter(processed_models, len(models)):
             if not isinstance(model, Exception):

--- a/modeldb/modeldb.py
+++ b/modeldb/modeldb.py
@@ -50,11 +50,22 @@ def download_model(arg_tuple):
             )
             # Replace the local file `model_zip_uri` with the zip file we
             # downloaded from `github_url`
-            github_response = requests.get(github_url)
-            assert github_response.status_code == requests.codes.ok
+            num_attempts = 3
+            status_codes = []
+            for _ in range(num_attempts):
+                github_response = requests.get(github_url)
+                status_codes.append(github_response.status_code)
+                if github_response.status_code == requests.codes.ok:
+                    break
+            else:
+                raise Exception(
+                    "Failed to download {} with status codes {}".format(
+                        github_url, status_codes
+                    )
+                )
             with open(model_zip_uri, "wb+") as zipfile:
                 zipfile.write(github_response.content)
-    except Exception as e:   #  noqa
+    except Exception as e:  #  noqa
         model = e
 
     return model_id, model

--- a/modeldb/modeldb.py
+++ b/modeldb/modeldb.py
@@ -89,7 +89,7 @@ class ModelDB(object):
         pool = multiprocessing.Pool()
         processed_models = pool.imap_unordered(
             download_model,
-            [(model_id, self._run_instr[model_id]) for model_id in models],
+            [(model_id, self._run_instr.get(model_id, {})) for model_id in models],
         )
         download_err = {}
         for model_id, model in ProgressBar.iter(processed_models, len(models)):

--- a/modeldb/modeldb.py
+++ b/modeldb/modeldb.py
@@ -4,6 +4,7 @@ import multiprocessing
 import base64
 import os
 import requests
+import time
 from .progressbar import ProgressBar
 import yaml
 from .data import Model
@@ -57,6 +58,7 @@ def download_model(arg_tuple):
                 status_codes.append(github_response.status_code)
                 if github_response.status_code == requests.codes.ok:
                     break
+                time.sleep(5)
             else:
                 raise Exception(
                     "Failed to download {} with status codes {}".format(


### PR DESCRIPTION
- Unzip the compressed data file in model 244262
- Update cache key to include the month => cache is never more than a month out of date.
- Support a `github` key in the YAML configuration that overwrites the ModelDB copy of a model with the GitHub copy.