### PR TITLE
subprocess.Popen need shell=True on windows.

### DIFF
--- a/modeldb/modelrun.py
+++ b/modeldb/modelrun.py
@@ -94,6 +94,7 @@ def append_log(model, model_sink, text):
 def run_commands(model, cmds, work_dir=None):
     out, _ = subprocess.Popen(
             cmds,
+            shell=True,
             stdout=subprocess.PIPE,
             stderr=subprocess.STDOUT,
             universal_newlines=True,


### PR DESCRIPTION
From a windows install of NEURON,
```bash-5.1$ runmodels --norun --workdir foo 3670```
succeeds in the sense of
```
$ cd foo/NTW_NEW
$ nrniv
NEURON -- VERSION 8.2a-109-gff2af9afd+ olupton/more-c++ (ff2af9afd+) 2022-06-09
Duke, Yale, and the BlueBrain Project -- Copyright 1984-2021
See http://neuron.yale.edu/neuron/credits

loading membrane mechanisms from E:\hines\models\nrn-modeldb-ci\foo\NTW_NEW\nrnmech.dll
Additional mechanisms from files
 HH2.mod IAHP.mod ICAN.mod IT2.mod capump.mod gabaa.mod gabab1.mod
oc>
```
and in foo.json, one can see that the compilation occurred. 