### PR TITLE
Clean up differences between neuron and neuron-nightly

### DIFF
--- a/.github/workflows/nrn-modeldb-ci.yaml
+++ b/.github/workflows/nrn-modeldb-ci.yaml
@@ -162,7 +162,14 @@ jobs:
           python -m pip install $NEURON_V1
         fi
         nrn_ver=`python -c "from neuron import __version__ as nrn_ver; print(nrn_ver)"`
-        runmodels --workdir=$nrn_ver $MODELS_TO_RUN
+        ps uxf # debug
+        runmodels --gout --workdir=$nrn_ver $MODELS_TO_RUN
+        # Filter out the gout data before generating HTML reports. The HTML
+        # diff uses the original gout files on disk anyway. Compress the large
+        # JSON file including gout data for inclusion in the artifacts
+        mv ${nrn_ver}.json ${nrn_ver}-full.json
+        jq -r 'del(.[].gout)' ${nrn_ver}-full.json > ${nrn_ver}.json
+        xz ${nrn_ver}-full.json
         report2html ${nrn_ver}.json
         if [[ -d "${DROP_DIR_V1}" ]]; then
           python -m pip uninstall --yes neuron-nightly==${nrn_ver}
@@ -182,7 +189,14 @@ jobs:
           python -m pip install $NEURON_V2
         fi
         nrn_ver=`python -c "from neuron import __version__ as nrn_ver; print(nrn_ver)"`
-        runmodels --workdir=$nrn_ver $MODELS_TO_RUN
+        ps uxf # debug
+        runmodels --gout --workdir=$nrn_ver $MODELS_TO_RUN
+        # Filter out the gout data before generating HTML reports. The HTML
+        # diff uses the original gout files on disk anyway. Compress the large
+        # JSON file including gout data for inclusion in the artifacts
+        mv ${nrn_ver}.json ${nrn_ver}-full.json
+        jq -r 'del(.[].gout)' ${nrn_ver}-full.json > ${nrn_ver}.json
+        xz ${nrn_ver}-full.json
         report2html ${nrn_ver}.json
         if [[ -d "${DROP_DIR_V2}" ]]; then
           python -m pip uninstall --yes neuron-nightly==${nrn_ver}
@@ -197,8 +211,9 @@ jobs:
         diffreports2html ${nrn1_ver}.json ${nrn2_ver}.json
 
     - uses: actions/upload-artifact@v3
+      if: ${{ always() }}
       with:
         name: ${{ env.nrn1_ver }}-vs-${{ env.nrn2_ver }}
         path: |
-          ./*.json
+          ./*.json.xz
           ./*.html

--- a/.github/workflows/nrn-modeldb-ci.yaml
+++ b/.github/workflows/nrn-modeldb-ci.yaml
@@ -147,7 +147,7 @@ jobs:
         path: |
           cache
           modeldb/modeldb-meta.yaml
-        key: models-${{steps.install-deps.outputs.date}}
+        key: models-${{steps.install-deps.outputs.date}}-fudge3
 
     - name: Get ModelDB models
       if: steps.cache-models.outputs.cache-hit != 'true'

--- a/.github/workflows/nrn-modeldb-ci.yaml
+++ b/.github/workflows/nrn-modeldb-ci.yaml
@@ -147,7 +147,7 @@ jobs:
         path: |
           cache
           modeldb/modeldb-meta.yaml
-        key: models-${{steps.install-deps.outputs.date}}-fudge3
+        key: models-${{steps.install-deps.outputs.date}}
 
     - name: Get ModelDB models
       if: steps.cache-models.outputs.cache-hit != 'true'

--- a/.github/workflows/nrn-modeldb-ci.yaml
+++ b/.github/workflows/nrn-modeldb-ci.yaml
@@ -162,7 +162,7 @@ jobs:
           python -m pip install $NEURON_V1
         fi
         nrn_ver=`python -c "from neuron import __version__ as nrn_ver; print(nrn_ver)"`
-        runmodels --virtual --workdir=$nrn_ver $MODELS_TO_RUN
+        runmodels --workdir=$nrn_ver $MODELS_TO_RUN
         report2html ${nrn_ver}.json
         if [[ -d "${DROP_DIR_V1}" ]]; then
           python -m pip uninstall --yes neuron-nightly==${nrn_ver}
@@ -182,7 +182,7 @@ jobs:
           python -m pip install $NEURON_V2
         fi
         nrn_ver=`python -c "from neuron import __version__ as nrn_ver; print(nrn_ver)"`
-        runmodels --virtual --workdir=$nrn_ver $MODELS_TO_RUN
+        runmodels --workdir=$nrn_ver $MODELS_TO_RUN
         report2html ${nrn_ver}.json
         if [[ -d "${DROP_DIR_V2}" ]]; then
           python -m pip uninstall --yes neuron-nightly==${nrn_ver}

--- a/modeldb/modeldb-run.yaml
+++ b/modeldb/modeldb-run.yaml
@@ -340,6 +340,9 @@
     - cat mosinit.hoc >> temp
     - mv temp  mosinit.hoc
 33975:
+    curate_patterns:
+    - pattern: 'hoc_run1: caught exception: hoc_execerror: We were unable to associate a PlayRecord item with a RANGE variable'
+      repl: ''
     run:
     - ringperf()
     - run()
@@ -504,10 +507,12 @@
     - run()
     - verify_graph_()
 83590:
+    model_dir: mechanisms
     run: []
     script:
     - sed -i'.bak' -e 's/mustart  = -0.400/mustart  = 0.800/g;s/sigmastart  = 0.064/sigmastart  = 0.128/g' mylibs/TFparams.hoc
 84589:
+    model_dir: mod
     run:
     - //ignore sim in subdirectory
     - // have not been able to run yet
@@ -561,6 +566,9 @@
 260971:
     comment: tricky to set-up due to mosinit.hoc autodiscovery
     skip: true
+83344:
+    github: 'pull/1'
+    model_dir: mod
 84655:
     run:
     - run()
@@ -605,6 +613,7 @@
     - restart("shortRun")
     - verify_graph_()
 94321:
+    model_dir: mechanisms
     run:
     - tstop=10
     - init()
@@ -635,6 +644,7 @@
     # avoid printing out times
     - sed -i'.bak' -e 's/^startsw()$/{startsw()}/g' ga_setup.hoc
 97860:
+    model_dir: mod
     run:
     - run()
     - verify_graph_()
@@ -676,6 +686,7 @@
     - fig9A1()
     - verify_graph_()
 105385:
+    model_dir: mod
     run:
     - loadfig9()
     - tstop=100
@@ -703,12 +714,14 @@
     - runeg()
     - verify_graph_()
 108458:
+    model_dir: mod
     run:
     - AP3_toq = 1
     - set_stim()
     - run()
     - verify_graph_()
 108459:
+    model_dir: mod
     run:
     - run()
     - verify_graph_()
@@ -781,6 +794,8 @@
     - tstop_changed()
     - run()
     - verify_graph_()
+114359:
+    model_dir: mod
 114394:
     run:
     - run()
@@ -865,6 +880,7 @@
     - run()
     - verify_graph_()
 117207:
+    model_dir: Model
     run:
     - restart("AckerAnticBasalBackprop")
     - RunAll()
@@ -886,6 +902,8 @@
     - Graph[0].exec_menu("View = plot")
     - verify_graph_()
 118631:
+    github: 'pull/1'
+    model_dir: mechanisms
     run:
     - use_mcell_ran4(1)
     - graph_and_run()
@@ -1004,6 +1022,10 @@
 139656:
     comment: //do not run
     run: null
+140471:
+    model_dir: mods
+140828:
+    model_dir: 'mod.files'
 140881:
     comment: //do not run Lytton model takes too long to run and complex to edit
     run: null
@@ -1018,8 +1040,12 @@
 141505:
     comment: //do not run Specialized installation environment
     run: null
+143604:
+    model_dir: mod
 144385:
-  model_dir: mod
+    model_dir: mod
+144482:
+    model_dir: mechanism/mechanism_cell1
 144523:
     run:
     - objref test_graph_
@@ -1043,6 +1069,8 @@
     run:
     - ParmFitnessGui[0].run()
     - verify_graph_()
+146026:
+    model_dir: channels
 146030:
     curate_patterns:
       - pattern: 'Setup time for simulation: [0-9]+\.[0-9]+  seconds'
@@ -1057,6 +1085,7 @@
     curate_patterns:
     - pattern: 't=([0-9\.]+);(\d+)\([0-9.\-e]+\)'
       repl: 't=\1;\2(%some_kind_of_clock%)'
+    github: 'pull/3'
     run:
     # main.hoc already calls run()
     - verify_graph_()
@@ -1069,12 +1098,19 @@
     run: null
 149739:
     run:
-    - demo_run()
     - verify_graph_()
+    script:
+    - mkdir Connection SP
+    - mv OB.hoc OB.hoc.iconv.bak
+    - iconv -f LATIN1 -t UTF-8 OB.hoc.iconv.bak > OB.hoc
+    - sed -i'.bak' 's#tstop   = 3000#tstop   = 10#g' OB.hoc
+150239:
+    model_dir: nrn/mod
 150245:
     curate_patterns:
       - pattern: 't=100\.00;122\([0-9]+\.[0-9]+\)'
         repl: 't=100.00;122(%some_kind_of_clock%)'
+    github: 'pull/3'
     run:
     - tstop=100
     - init()
@@ -1083,49 +1119,98 @@
 150284:
     comment: //do not run Mattione Le Novere missing _run_me.hoc in parallel model
     run: null
+151443:
+    model_dir: channels
 167772:
     comment: //do not run Tried "initDialog.unmap(1)" - didnt work.  Need to change
         archive
     run: null
+168310:
+    model_dir: experiment
+168314:
+    script:
+    # fixup for case-sensitive filesystems
+    - sed -i'.bak' 's#path = "./inputs/"#path = "./Inputs/"#g' ReadExperiments.hoc
+    - sed -i'.bak' 's#load_file("protocol.hoc")#load_file("Protocol.hoc")#g' Hipp.hoc
+184054:
+    model_dir: fullMorphCaLTP8
+    script:
+    - sed -i'.bak' 's#tstop = 250#tstop = 25#g' fullMorphCaLTP8/doTBSStimCC.hoc
+187473:
+    model_dir: mods
 187604:
   curate_patterns:
     - pattern: 'TIME HOST 0: [0-9\.]+ seconds \(set up\)'
       repl: 'TIME HOST 0: %elapsed_time% seconds (set up)'
     - pattern: 'TIME HOST 0: [0-9\.]+ seconds \(created cells\)'
       repl: 'TIME HOST 0: %elapsed_time% seconds (created cells)'
+187615:
+    comment: Tries to open bac6.ses, which does not exist
+    run: null
+189347:
+    script:
+    # we launch with special so don't try and dlopen mechanisms too
+    - sed -i'.bak' 's#nrn_load_dll#// nrn_load_dll#g' main.hoc
+195666:
+    model_dir: mod_files
 206244:
     run:
     - chdir("mechanism")
     - xopen("mosinit.hoc")
     - unix_spike_atten_hof()
     - verify_graph_()
+222359:
+    script:
+    # Fix for case-sensitive filesystems
+    - mv Voltage.ses voltage.ses
 223962:
     skip: true
     comment: takes too long, need to see how to reduce time
 229276:
     model_dir: mechanisms
     script:
+    - mkdir hoc_recordings
     - cp template.hoc template.hoc.iconv.bak
     - cp createsimulation.hoc createsimulation.hoc.iconv.bak
     - iconv -f LATIN1 -t UTF-8 template.hoc.iconv.bak > template.hoc
     - iconv -f LATIN1 -t UTF-8 createsimulation.hoc.iconv.bak > createsimulation.hoc
     - sed -i'.bak' -e 's#^tstop=\([0-9a-z+]*\)#tstop=((\1)/500)#g' createsimulation.hoc
+    - sed -i'.bak' 's#\(cell.synapses.update_synapses(synapse_plot)\)#// \1#g' init_super.hoc
+232097:
+    script:
+    - mkdir connection input
+237594:
+    model_dir: mechanism
 244262:
     script:
     - if [[ ! -f Iintra.dat ]]; then unzip Iintra.dat.zip; fi
     - ls -l Iintra.dat
+249463:
+    comment: Tries to open bac6.ses, which does not exist
+    run: null
+254217:
+    model_dir: _mod
+256024:
+    model_dir: mods
 149174:
     skip: true
     comment: testing in Python + hardcoded NEURON
 258867:
-    run:
-    - run()
-    - verify_graph_()
+    run: null
     script:
     - sed -i'.bak' -e 's/tstop = /tstop = 50\/\//' Fig8_tuft_NMDA_spike.hoc
     - sed -i'.bak' -e 's/simul_iter=/simul_iter=2 \/\//' Fig8_tuft_NMDA_spike.hoc
-    comment: usual simulation time is ~ 10 minutes (tstop = 120 and simul_iter=10)
+    comment: 'Usual simulation time is ~ 10 minutes (tstop = 120 and simul_iter=10), skipped because it tries to load C:/Daten/Modeling/Alpha5_NMDA_single_comp/shared/ATF.hoc'
+260178:
+    model_dir: _mod
+260967:
+    model_dir: lib
+266818:
+    script:
+    - sed -i'.bak' '1s/^/{load_file("stdlib.hoc")}\n/' hoc_tools/nav_states.hoc
+    - sed -i'.bak' '1s/^/{load_file("stdgui.hoc")}\n/' hoc_tools/plots.hoc
 267067:
+    github: 'pull/3'
     # This model ID seems to have two ~different models inside it. Arbitrarily choose one.
     model_dir: 'Na12 Analysis/mechanisms'
     run:
@@ -1135,8 +1220,18 @@
     - (cd "Na12 Analysis" && mv mosinit.hoc mosinit.hoc.bak && ln -s runModel.hoc mosinit.hoc)
     - sed -i'.bak' -e 's#\./mosinit\.hoc#./mosinit.hoc.bak#g' 'Na12 Analysis/runModel.hoc'
     - sed -i'.bak' -e 's#^tstop=30000#tstop=100#g' 'Na12 Analysis/constants.hoc'
+267293:
+    comment: Tries to open bac6.ses, which does not exist
+    run: null
 267384:
     model_dir: 'BBP_TTPC_EXAMPLE'
+    script:
+    # 12 is the largest value (runModel-template.hoc); this is a guess
+    - sed -i'.bak' 's#load_file("nrngui.hoc")#objref transvec\ntransvec = new Vector(12)\nload_file("nrngui.hoc")#' BBP_TTPC_EXAMPLE/mosinit.hoc
+267594:
+    comment: 'Seems to be missing files: parinit.hoc, .mod file for h_ca, ...?'
+    model_dir: mods
+    run: null
 206267:
     run:
     - run()

--- a/modeldb/modeldb-run.yaml
+++ b/modeldb/modeldb-run.yaml
@@ -567,7 +567,6 @@
     comment: tricky to set-up due to mosinit.hoc autodiscovery
     skip: true
 83344:
-    github: 'pull/1'
     model_dir: mod
 84655:
     run:
@@ -902,7 +901,6 @@
     - Graph[0].exec_menu("View = plot")
     - verify_graph_()
 118631:
-    github: 'pull/1'
     model_dir: mechanisms
     run:
     - use_mcell_ran4(1)
@@ -1085,7 +1083,6 @@
     curate_patterns:
     - pattern: 't=([0-9\.]+);(\d+)\([0-9.\-e]+\)'
       repl: 't=\1;\2(%some_kind_of_clock%)'
-    github: 'pull/3'
     run:
     # main.hoc already calls run()
     - verify_graph_()
@@ -1110,7 +1107,6 @@
     curate_patterns:
       - pattern: 't=100\.00;122\([0-9]+\.[0-9]+\)'
         repl: 't=100.00;122(%some_kind_of_clock%)'
-    github: 'pull/3'
     run:
     - tstop=100
     - init()
@@ -1210,7 +1206,6 @@
     - sed -i'.bak' '1s/^/{load_file("stdlib.hoc")}\n/' hoc_tools/nav_states.hoc
     - sed -i'.bak' '1s/^/{load_file("stdgui.hoc")}\n/' hoc_tools/plots.hoc
 267067:
-    github: 'pull/3'
     # This model ID seems to have two ~different models inside it. Arbitrarily choose one.
     model_dir: 'Na12 Analysis/mechanisms'
     run:

--- a/modeldb/modelrun.py
+++ b/modeldb/modelrun.py
@@ -209,16 +209,18 @@ def prepare_model(model):
             os.path.join(MODELS_ZIP_DIR, str(model.id) + ".zip"), "r"
     ) as zip_ref:
         model_dir = os.path.join(
-            model.working_dir, os.path.dirname(zip_ref.infolist()[0].filename)
+            model.working_dir,
+            str(model.id),
+            os.path.dirname(zip_ref.infolist()[0].filename),
         )
-        model_run_info_file = os.path.join(model_dir, str(model.id) + '.yaml')
+        model_run_info_file = os.path.join(model_dir, str(model.id) + ".yaml")
         if model._inplace and os.path.isfile(model_run_info_file):
             with open(model_run_info_file) as run_info_file:
                 model["run_info"] = yaml.load(run_info_file, yaml.Loader)
         else:
             if model._clean and is_dir_non_empty(model_dir):
                 shutil.rmtree(model_dir)
-            zip_ref.extractall(model.working_dir)
+            zip_ref.extractall(os.path.join(model.working_dir, str(model.id)))
 
             # set model_dir
             model.run_info["model_dir"] = model_dir

--- a/modeldb/report.py
+++ b/modeldb/report.py
@@ -61,8 +61,11 @@ def diff_reports(report1_json, report2_json):
         hd = difflib.HtmlDiff()
         v1 = data_a["0"]["NEURON version"]
         v2 = data_b["0"]["NEURON version"]
-        diff_dict["0"] = hd.make_table(json.dumps(data_a["0"], indent='\t').split('\n'),
-                                             json.dumps(data_b["0"], indent='\t').split('\n')).replace("\n", "")
+        diff_dict["0"] = hd.make_table(
+            json.dumps(data_a["0"], indent="\t").split("\n"),
+            json.dumps(data_b["0"], indent="\t").split("\n"),
+        ).replace("\n", "")
+        stats_dict = {v1: data_a["0"]["Stats"], v2: data_b["0"]["Stats"]}
         for k in data_a.keys():
             if int(k) == 0:
                 continue  # skip info key
@@ -103,11 +106,11 @@ def diff_reports(report1_json, report2_json):
                 # gout may be missing in one of the paths. `diff -N` treats non-existent files as empty.
                 if os.path.isfile(gout_a_file) or os.path.isfile(gout_b_file):
                     diff_out = subprocess.getoutput(
-                        "diff -uN {} {} | head -n 30".format(
+                        "diff -uN --speed-large-files {} {} | head -n 30".format(
                             shlex.quote(gout_a_file), shlex.quote(gout_b_file)
                         )
                     )
                     if diff_out:
                         gout_dict[k] = highlight(diff_out, DiffLexer(), HtmlFormatter(linenos=True, cssclass="colorful", full=True))
 
-    return diff_dict, gout_dict, runtime_dict, v1, v2
+    return diff_dict, gout_dict, runtime_dict, stats_dict, v1, v2


### PR DESCRIPTION
Many of the diffs are due to error messages that are, in essence, the same on both sides of the comparison.
Some error message formatting has changed since NEURON 8.2.2, so "the same error" can still result in a diff.
This is an effort to avoid the problem by fixing the errors, with obvious benefits.

To be merged first + `github:` keys removed from YAML in this PR:
- [x] https://github.com/ModelDBRepository/83344/pull/1
- [x] https://github.com/ModelDBRepository/118631/pull/1
- [x] https://github.com/ModelDBRepository/146949/pull/3
- [x] https://github.com/ModelDBRepository/150245/pull/3
- [x] https://github.com/ModelDBRepository/267067/pull/3