### PR TITLE
Remove hardcoded line number

### DIFF
--- a/modeldb/modeldb-run.yaml
+++ b/modeldb/modeldb-run.yaml
@@ -350,7 +350,7 @@
       repl: ''
     - pattern: '%neuron-executable%: We were unable to associate a PlayRecord item with a RANGE variable'
       repl: ''
-    - pattern: ' in %model_dir%/driver.hoc near line 44'
+    - pattern: ' in %model_dir%/driver.hoc near line \d+'
       repl: ''
     - pattern: '^\s+(finitialize|init|run|stdinit)\((|-65)\)'
       repl: ''


### PR DESCRIPTION
Most likely this was broken when I cleaned up https://github.com/neuronsimulator/nrn-modeldb-ci/pull/67 in 4e6e5ce9f327ffed7f14ff36f07926e3316c060c and stopped appending 7 lines to `driver.hoc`. 

https://github.com/neuronsimulator/nrn/actions/runs/4859158250 fails because
```
 in %model_dir%/driver.hoc near line 37
```
fails to be removed from the diff.

MODELS_TO_RUN=33975