### PR TITLE
Improve error and diff handling

### DIFF
--- a/modeldb/commands.py
+++ b/modeldb/commands.py
@@ -249,8 +249,7 @@ def diffreports2html(args=None):
         print("FAILURE: stdout diffs in {}".format(set(diff_dict.keys()) - {"0"}))
         code = 1
     if len(gout_dict) > 1:
-        assert "0" in gout_dict  # summary info; not a real diff
-        print("FAILURE: gout diffs in {}".format(set(diff_dict.keys()) - {"0"}))
+        print("FAILURE: gout diffs in {}".format(set(gout_dict.keys())))
         code = 1
     total_failures = sum(
         version_stats["Failed models"]["Count"] for version_stats in stats_dict.values()

--- a/modeldb/modeldb-run.yaml
+++ b/modeldb/modeldb-run.yaml
@@ -1237,6 +1237,8 @@
     comment: 'Seems to be missing files: parinit.hoc, .mod file for h_ca, ...?'
     model_dir: mods
     run: null
+267691:
+    model_dir: mechanisms
 206267:
     run:
     - run()

--- a/modeldb/modeldb-run.yaml
+++ b/modeldb/modeldb-run.yaml
@@ -1018,7 +1018,7 @@
     # - it tries to access /proc/uptime, which is not portable
     # - if that works (i.e. on Linux) it runs with a different seed every time,
     #   which is unhelpful in a CI context
-    -  sed -i'.bak' -e 's#ropen(#// ropen(#g;s#rseed = fscan()#rseed=424242#g' 50knet.hoc
+    -  sed -i'.bak' -e 's#ropen("/proc/uptime")#// ropen("/proc/uptime")#g;s#rseed = fscan()#rseed=424242#g' 50knet.hoc
 136095:
     run:
     - run()

--- a/modeldb/modeldb-run.yaml
+++ b/modeldb/modeldb-run.yaml
@@ -1113,6 +1113,13 @@
 147461:
     comment: //do not run Minimum time would be 1/2 hr default time is about 8.3 hours
     run: null
+148253:
+    script:
+    # there are two problems with the code in this model:
+    # - it tries to access /proc/uptime, which is not portable
+    # - if that works (i.e. on Linux) it runs with a different seed every time,
+    #   which is unhelpful in a CI context
+    -  sed -i'.bak' -e 's#ropen(#// ropen(#g;s#rseed = fscan()#rseed=424242#g' init_ClmIPSCs_GC.hoc
 149739:
     run:
     - verify_graph_()

--- a/modeldb/modeldb-run.yaml
+++ b/modeldb/modeldb-run.yaml
@@ -1259,7 +1259,16 @@
     model_dir: mods
     run: null
 267691:
+    # output is two data files Vm_6_1.dat Vm_axon_6_1.dat, which should be compared...
+    github: "pull/1"
     model_dir: mechanisms
+    script:
+    # based on mosinit.ps1 file in the repository
+    - ln -s init_icms.hoc mosinit.hoc
+    # reduce the cell count from 448 to 1 (this sed command works for cell_id = 6 below)
+    - sed -i'.bak' -e 's#4.4800000e+02#1.0000000e+00#g' cell_cnt.dat
+    # it seems the scripts expect cell_id to be passed on the commandline when special is run
+    - sed -i'.bak' -e 's#// cell_id = 6#cell_id = 6#' init_icms.hoc
 206267:
     run:
     - run()

--- a/modeldb/modeldb-run.yaml
+++ b/modeldb/modeldb-run.yaml
@@ -1260,7 +1260,6 @@
     run: null
 267691:
     # output is two data files Vm_6_1.dat Vm_axon_6_1.dat, which should be compared...
-    github: "pull/1"
     hoc_stack_size: 2000 # default of 1000 is apparently not enough
     model_dir: mechanisms
     script:

--- a/modeldb/modeldb-run.yaml
+++ b/modeldb/modeldb-run.yaml
@@ -359,6 +359,8 @@
       repl: ''
     - pattern: '^\s+\^'
       repl: ''
+    # this should be removed once the latest release and development branch include nrn#2027
+    ignore_exit_code: true
     run:
     - ringperf()
     - run()

--- a/modeldb/modeldb-run.yaml
+++ b/modeldb/modeldb-run.yaml
@@ -1261,6 +1261,7 @@
 267691:
     # output is two data files Vm_6_1.dat Vm_axon_6_1.dat, which should be compared...
     github: "pull/1"
+    hoc_stack_size: 2000 # default of 1000 is apparently not enough
     model_dir: mechanisms
     script:
     # based on mosinit.ps1 file in the repository

--- a/modeldb/modeldb-run.yaml
+++ b/modeldb/modeldb-run.yaml
@@ -315,6 +315,9 @@
     - xopen("mosinit.hoc")
     - unix_spike_atten_hof()
     - verify_graph_()
+    script:
+    # Model tries to abort on mac, but let's try and run it anyway
+    - sed -i'.bak' -e 's#if (unix_mac_pc() ==1 || unix_mac_pc() ==3 ) {#if (1) { // assume works on mac/linux/windows#g' mechanism/mosinit.hoc
 20756:
     run:
     - 'pyr3_ = new pyr3( 21 ) '

--- a/modeldb/modeldb-run.yaml
+++ b/modeldb/modeldb-run.yaml
@@ -1012,6 +1012,13 @@
     - verify_graph_()
     script: # todo -> fix model for NEURON 8.0.0 and remove this script
     - sed -i'.bak' -e 's/return 0;//g' MOPP_Fig_1B_left/ichan2.mod
+124513:
+    script:
+    # there are two problems with the code in this model:
+    # - it tries to access /proc/uptime, which is not portable
+    # - if that works (i.e. on Linux) it runs with a different seed every time,
+    #   which is unhelpful in a CI context
+    -  sed -i'.bak' -e 's#ropen(#// ropen(#g;s#rseed = fscan()#rseed=424242#g' 50knet.hoc
 136095:
     run:
     - run()

--- a/modeldb/modeldb-run.yaml
+++ b/modeldb/modeldb-run.yaml
@@ -1142,6 +1142,7 @@
 150284:
     comment: //do not run Mattione Le Novere missing _run_me.hoc in parallel model
     run: null
+# 150551: segfault with cal4.mod in 8.2.2 on macOS, see https://github.com/neuronsimulator/nrn/issues/2206
 151443:
     model_dir: channels
 167772:
@@ -1242,6 +1243,7 @@
     - (cd "Na12 Analysis" && mv mosinit.hoc mosinit.hoc.bak && ln -s runModel.hoc mosinit.hoc)
     - sed -i'.bak' -e 's#\./mosinit\.hoc#./mosinit.hoc.bak#g' 'Na12 Analysis/runModel.hoc'
     - sed -i'.bak' -e 's#^tstop=30000#tstop=100#g' 'Na12 Analysis/constants.hoc'
+# 267140: segfaults with cal4.mod in 8.2.2 on macOS, see https://github.com/neuronsimulator/nrn/issues/2206
 267293:
     comment: Tries to open bac6.ses, which does not exist
     run: null
@@ -1278,6 +1280,7 @@
 #    - sed 's/tstop=/tstop=20\/\//g' Fig_13.hoc > temp.tmp
 #    - mv temp.tmp Fig_13.hoc
 244922:
+    # segfaults with cal4.mod in 8.2.2 on macOS, see https://github.com/neuronsimulator/nrn/issues/2206
     run:
     - run()
     - verify_graph_()

--- a/modeldb/modelrun.py
+++ b/modeldb/modelrun.py
@@ -127,7 +127,7 @@ def run_neuron_cmds(model, cmds):
     except UnicodeDecodeError:
         raise Exception("Could not decode output:" + repr(out))
     model.nrn_run.extend(curate_log_string(model, out).splitlines())
-    if sp.returncode != 0:
+    if sp.returncode != 0 and not model.get("ignore_exit_code", False):
         model._nrn_run_error = True
 
 
@@ -313,7 +313,8 @@ def run_model(model):
                     model._gout = gout.readlines()
         except Exception:  # noqa
             append_log(model, model.nrn_run, traceback.format_exc())
-            model._nrn_run_error = True
+            if not model.get("ignore_exit_code", False):
+                model._nrn_run_error = True
 
     stop_time = time.perf_counter()
     model._run_times["model"] = stop_time - start_time
@@ -432,6 +433,8 @@ class ModelRunManager(object):
                 self.run_logs[model.id]["do_not_run"] = True
             if model.nrn_run_error:
                 self.run_logs[model.id]["nrn_run_err"] = True
+            if model.get("ignore_exit_code", False):
+                self.run_logs[model.id]["ignore_exit_code"] = True
             if model.no_mosinit_hoc:
                 self.run_logs[model.id]["no_mosinit_hoc"] = True
             self.run_logs[model.id]["run_info"] = model.run_info

--- a/modeldb/modelrun.py
+++ b/modeldb/modelrun.py
@@ -304,6 +304,8 @@ def run_model(model):
             nrn_exe = "./{}/special".format(platform.machine()) if mods is not None and len(mods) else "nrniv"
             # '-nogui' creates segfault
             model_run_cmds = [nrn_exe, '-nobanner']
+            if "hoc_stack_size" in model:
+                model_run_cmds += ["-NSTACK", str(int(model["hoc_stack_size"]))]
             if model.run_py:
                 model_run_cmds.append('-python')
             model_run_cmds += [model.run_info["init"], model.run_info["driver"]]

--- a/modeldb/modelrun.py
+++ b/modeldb/modelrun.py
@@ -176,7 +176,8 @@ def build_quit_hoc(model):
 def select_mosinit(model):
     # look for `mosinit.hoc`. It could also be produced by `init` script above
     mosfiles = glob.glob(model.model_dir + "/**/mosinit.hoc", recursive=True)
-    mosfiles.sort()
+    # prefer less-nested directories, then sort alphabetically
+    mosfiles.sort(key=lambda x: (x.count(os.sep), x))
     if len(mosfiles):
         model.run_info["start_dir"] = os.path.dirname(os.path.join(model.model_dir, mosfiles[0]))
         model.run_info["init"] = mosfiles[0]

--- a/modeldb/modelrun.py
+++ b/modeldb/modelrun.py
@@ -127,7 +127,7 @@ def run_neuron_cmds(model, cmds):
     except UnicodeDecodeError:
         raise Exception("Could not decode output:" + repr(out))
     model.nrn_run.extend(curate_log_string(model, out).splitlines())
-    if sp.returncode > 1:
+    if sp.returncode != 0:
         model._nrn_run_error = True
 
 


### PR DESCRIPTION
- Previously error code 1 was counted as success.
- When `gout` diffs were large, making the HTML report could be very slow. Add a timeout.
- Start to address more issues in new and existing models.