### PR TITLE
fix bug in report.py

### DIFF
--- a/modeldb/report.py
+++ b/modeldb/report.py
@@ -135,6 +135,8 @@ def diff_reports(report1_json, report2_json):
                                     )
                                 ]
                             )
+                        else:
+                            diff_out = "\n".join(diff_out)
                     except subprocess.TimeoutExpired:
                         child.kill()
                         diff_out = (


### PR DESCRIPTION
The variable `diff_out` is supposed to be a string but it accidentally got split into a list of lines and it's never joined back into a string. This PR ensures that `diff_out` is always converted back into a string.