### PR TITLE
model id is occasionally different from the id of the zip file

### DIFF
--- a/modeldb/modeldb-run.yaml
+++ b/modeldb/modeldb-run.yaml
@@ -592,6 +592,12 @@
 260971:
     comment: tricky to set-up due to mosinit.hoc autodiscovery
     skip: true
+82894:
+    model_dir: mod
+    run:
+    - exact(1)
+    - run()
+    - verify_graph_()
 83344:
     model_dir: mod
 84655:


### PR DESCRIPTION
NEURON implementation identifiers are not always identical to model entry identifiers. For example, the entry identifier for
the 2005 Traub model is 45539 but the ifc fortran implementation is downloaded if that entry identifier is used for database download. This PR uses the NEURON implementation identifier instead of the entry identifier for
```
data.Model._object_id
```
A wrinkle is that a model entry identifier may have multiple distinct NEURON implementation identifiers.

Closes #94

It may be worthwhile to modify this PR so that ```data.Model._object_id``` continues to refer to the model entry identifier and  add a ```data.Model._zip_id``` to refer to the id used for zip file download. Note that the ModelDB.metatdata dictionary now has
NEURON implementation identifiers for keys.
field to refer to the implementation identifier