### PR TITLE
Exclude failing model from running in CI

### DIFF
--- a/modeldb/modeldb-run.yaml
+++ b/modeldb/modeldb-run.yaml
@@ -1160,9 +1160,7 @@
       repl: ''
     - pattern: '\s*\^\s*'
       repl: ''
-    run:
-    - run()
-    - verify_graph_()
+    run: null
     script:
     - sed -i'.bak' -r 's/(tstop=mytstop=htmax= \(LearnDur \+ ZipDur \+ BaseDur\*2\) \*) 1e3/\1 2e1/g' params.hoc
 144579:


### PR DESCRIPTION
The model https://github.com/ModelDBRepository/144538 is failing in the CI using NEURON 9 with the following error:

```plaintext
%neuron-executable%: syntax error
 in arm.hoc near line 163
       nqDP.append(1,xo.id,DP,xo.zloc,MTYP.o(xo.zloc).s,shminmlen,shmaxmlen)
                                          ^
        xopen("arm.hoc")
      execute1("{xopen("ar...")
    load_file("arm.hoc")
%neuron-executable%: hoc_Load_file arm.hoc
 in arm.hoc near line 33
 ^
        load_file("arm.hoc")
hoc_run1: caught exception: hoc_execerror: hoc_Load_file arm.hoc
```

It's not really clear what the source of the problem is, and as the model is quite old, it's probably better to fix it later, but exclude it from the CI in the meantime.