### PR TITLE
Set different source for 2014998

### DIFF
--- a/modeldb/modeldb-run.yaml
+++ b/modeldb/modeldb-run.yaml
@@ -1854,3 +1854,5 @@
         repl: ''
       - pattern: '\s*\^\s*'
         repl: ''
+2014998:
+    github: 'default'


### PR DESCRIPTION
Model 2014998 needs some minor changes in order to be compatible with NEURON 9, and for now we set the source to `github: default` which has them.
Verification: https://github.com/neuronsimulator/nrn-modeldb-ci/actions/runs/7615231720