### PR TITLE
Remove warnings about dynamic units in additional models

### DIFF
--- a/modeldb/modeldb-run.yaml
+++ b/modeldb/modeldb-run.yaml
@@ -14,6 +14,15 @@
     run:
     - run()
     - verify_graph_()
+    curate_patterns:
+      - pattern: '%neuron-executable%: Assignment to modern physical constant \w+'
+        repl: ''
+      - pattern: ' in .*\.hoc near line \d+'
+        repl: ''
+      - pattern: ' FARADAY.*'
+        repl: ''
+      - pattern: '\s*\^\s*'
+        repl: ''
 2798:
     run:
     - run_c()
@@ -31,6 +40,15 @@
     run:
     - runb()
     - verify_graph_()
+    curate_patterns:
+      - pattern: '%neuron-executable%: Assignment to modern physical constant \w+'
+        repl: ''
+      - pattern: ' in .*\.hoc near line \d+'
+        repl: ''
+      - pattern: ' FARADAY.*'
+        repl: ''
+      - pattern: '\s*\^\s*'
+        repl: ''
 3264:
     run:
     - use_mcell_ran4(1)
@@ -202,10 +220,28 @@
     run:
     - runc()
     - verify_graph_()
+    curate_patterns:
+      - pattern: '%neuron-executable%: Assignment to modern physical constant \w+'
+        repl: ''
+      - pattern: ' in .*\.hoc near line \d+'
+        repl: ''
+      - pattern: ' FARADAY.*'
+        repl: ''
+      - pattern: '\s*\^\s*'
+        repl: ''
 7659:
     run:
     - runp()
     - verify_graph_()
+    curate_patterns:
+      - pattern: '%neuron-executable%: Assignment to modern physical constant \w+'
+        repl: ''
+      - pattern: ' in .*\.hoc near line \d+'
+        repl: ''
+      - pattern: ' FARADAY.*'
+        repl: ''
+      - pattern: '\s*\^\s*'
+        repl: ''
 7907:
     comment: ".mod files do not compile"
     # Based on readme, other choices are available
@@ -416,6 +452,15 @@
     run:
     - run_short()
     - verify_graph_()
+    curate_patterns:
+      - pattern: '%neuron-executable%: Assignment to modern physical constant \w+'
+        repl: ''
+      - pattern: ' in .*\.hoc near line \d+'
+        repl: ''
+      - pattern: ' FARADAY.*'
+        repl: ''
+      - pattern: '\s*\^\s*'
+        repl: ''
 53435:
     comment: // disregard. mod files in subdirectory
     skip: true
@@ -546,6 +591,15 @@
     - // load_file("cells/d151.hoc")
     - // load_file("hoc/src/file_util.hoc")
     - // load_file("hoc/src/main.hoc")
+    curate_patterns:
+      - pattern: '%neuron-executable%: Assignment to modern physical constant \w+'
+        repl: ''
+      - pattern: ' in .*\.hoc near line \d+'
+        repl: ''
+      - pattern: ' FARADAY.*'
+        repl: ''
+      - pattern: '\s*\^\s*'
+        repl: ''
 84612:
     model_dir: "."
     run:
@@ -1188,6 +1242,14 @@
     curate_patterns:
     - pattern: 't=([0-9\.]+);(\d+)\([0-9.\-e]+\)'
       repl: 't=\1;\2(%some_kind_of_clock%)'
+    - pattern: '%neuron-executable%: Assignment to modern physical constant \w+'
+      repl: ''
+    - pattern: ' in .*\.hoc near line \d+'
+      repl: ''
+    - pattern: ' FARADAY.*'
+      repl: ''
+    - pattern: '\s*\^\s*'
+      repl: ''
     run:
     # main.hoc already calls run()
     - verify_graph_()
@@ -1227,6 +1289,14 @@
     curate_patterns:
       - pattern: 't=100\.00;122\([0-9]+\.[0-9]+\)'
         repl: 't=100.00;122(%some_kind_of_clock%)'
+      - pattern: '%neuron-executable%: Assignment to modern physical constant \w+'
+        repl: ''
+      - pattern: ' in .*\.hoc near line \d+'
+        repl: ''
+      - pattern: ' FARADAY.*'
+        repl: ''
+      - pattern: '\s*\^\s*'
+        repl: ''
     run:
     - tstop=100
     - init()
@@ -1360,6 +1430,15 @@
 232097:
     script:
     - mkdir connection input
+    curate_patterns:
+      - pattern: '%neuron-executable%: Assignment to modern physical constant \w+'
+        repl: ''
+      - pattern: ' in .*\.hoc near line \d+'
+        repl: ''
+      - pattern: ' R\s*=\s*500.*'
+        repl: ''
+      - pattern: '\s*\^\s*'
+        repl: ''
 232876:
     # Arbitrarily choose this over influence_ih_iT/ and high_conductance_state/
     model_dir: "current_clamp"
@@ -1705,3 +1784,73 @@
         repl: ''
 267694:
     model_dir: mouse_model/mod_files
+29942:
+    curate_patterns:
+      - pattern: '%neuron-executable%: Assignment to modern physical constant \w+'
+        repl: ''
+      - pattern: ' in .*\.hoc near line \d+'
+        repl: ''
+      - pattern: ' FARADAY.*'
+        repl: ''
+      - pattern: '\s*\^\s*'
+        repl: ''
+181967:
+    curate_patterns:
+      - pattern: '%neuron-executable%: Assignment to modern physical constant \w+'
+        repl: ''
+      - pattern: ' in .*\.hoc near line \d+'
+        repl: ''
+      - pattern: ' FARADAY.*'
+        repl: ''
+      - pattern: '\s*\^\s*'
+        repl: ''
+35358:
+    curate_patterns:
+      - pattern: '%neuron-executable%: Assignment to modern physical constant \w+'
+        repl: ''
+      - pattern: ' in .*\.hoc near line \d+'
+        repl: ''
+      - pattern: ' FARADAY.*'
+        repl: ''
+      - pattern: '\s*\^\s*'
+        repl: ''
+37819:
+    curate_patterns:
+      - pattern: '%neuron-executable%: Assignment to modern physical constant \w+'
+        repl: ''
+      - pattern: ' in .*\.hoc near line \d+'
+        repl: ''
+      - pattern: ' FARADAY.*'
+        repl: ''
+      - pattern: '\s*\^\s*'
+        repl: ''
+7399:
+    curate_patterns:
+      - pattern: '%neuron-executable%: Assignment to modern physical constant \w+'
+        repl: ''
+      - pattern: ' in .*\.hoc near line \d+'
+        repl: ''
+      - pattern: ' FARADAY.*'
+        repl: ''
+      - pattern: '\s*\^\s*'
+        repl: ''
+7400:
+    curate_patterns:
+      - pattern: '%neuron-executable%: Assignment to modern physical constant \w+'
+        repl: ''
+      - pattern: ' in .*\.hoc near line \d+'
+        repl: ''
+      - pattern: ' FARADAY.*'
+        repl: ''
+      - pattern: '\s*\^\s*'
+        repl: ''
+9889:
+    curate_patterns:
+      - pattern: '%neuron-executable%: Assignment to modern physical constant \w+'
+        repl: ''
+      - pattern: ' in .*\.hoc near line \d+'
+        repl: ''
+      - pattern: ' FARADAY.*'
+        repl: ''
+      - pattern: '\s*\^\s*'
+        repl: ''


### PR DESCRIPTION
Same fix as #100, but for the following models:

- 146949
- 2796
- 35358
- 29942
- 52034
- 181967
- 150245
- 7659
- 9889
- 7399
- 7386
- 7400
- 84589
- 37819
- 232097
- 3263