### PR TITLE
Filter output from 180373

### DIFF
--- a/modeldb/modeldb-run.yaml
+++ b/modeldb/modeldb-run.yaml
@@ -620,6 +620,9 @@
     script:
     - printf 'VERBATIM\nextern void state_discontinuity(int i, double* pd, double d);\nENDVERBATIM\n' >> simulationcode/glutamate.mod
     - ln -sf driver.hoc simulationcode/driver.hoc
+    curate_patterns:
+      - pattern: '\s*Vector.*'
+        repl: ''
 186977:
     model_dir: mods/network_sims_MODs
     run:


### PR DESCRIPTION
The call to `<Vector>.plot` in `Fig3A.hoc` outputs `Vector[<int>]` to stdout which does not seem to have an impact on the results.
Verification: https://github.com/neuronsimulator/nrn-modeldb-ci/actions/runs/7626068663