### PR TITLE
Fix multiple mod file dirs in 266498

### DIFF
--- a/modeldb/modeldb-run.yaml
+++ b/modeldb/modeldb-run.yaml
@@ -1859,3 +1859,5 @@
         repl: ''
 2014998:
     github: 'default'
+266498:
+    model_dir: 'MultiCompartmentModels/Mod'


### PR DESCRIPTION
A recent [model update](https://github.com/ModelDBRepository/266498/commit/f7d1fab5099e43886666c3e0dffc7be3d85a94cf) broke the CI. Not really sure why it was working in the first place though since it had multiple mod directories even before the update.
MODELS_TO_RUN=266498