### PR TITLE
modeldb-meta.yaml clone or copy a local repository

### DIFF
--- a/modeldb/modeldb.py
+++ b/modeldb/modeldb.py
@@ -30,7 +30,7 @@ def download_model(arg_tuple):
         # from ModelDB, but it can be overriden to come from GitHub instead.
         if "github" in model_run_info:
             # This means we should try to download the model content from
-            # GitHub instead of from ModelDB.
+            # GitHub instead of from ModelDB. (but see the local: case below.)
             github = model_run_info["github"]
             organisation = "ModelDBRepository"
             suffix = ""  # default branch
@@ -57,6 +57,27 @@ def download_model(arg_tuple):
                 # if you need to test changes to a model that does not exist on
                 # GitHub under the ModelDBRepository organisation.
                 organisation = github[1:]
+            elif github.startswith("local:"):
+                # Using
+                #  github: "local: /path/to/repository"
+                # in modeldb-run.yaml implies that we 'git clone /path/to/repository'.
+                # This is useful to tentatively explore the effect of
+                # model changes on results with different nrn versions
+                # without committing to github or before being ready to
+                # make a pull request
+                print("\nTo be cloned by runmodel", github)
+                return model_id, model
+            elif github.startswith("copy:"):
+                # Using
+                #  github: "copy: /path/to/parentfolder"
+                # in modeldb-run.yaml implies that we
+                #  'cp -R /path/to/parentfolder/<id> <workingdir>'
+                # A copy differs from a clone in that local changes in
+                # the checkout are mirrored in the copy without having to
+                # be committed. Note the copy leaves out the .git and
+                # x86_64 folders.
+                print("\nTo be copied by runmodel %s/%s" % (github, model_id))
+                return model_id, model
             else:
                 raise Exception("Invalid value for github key: {}".format(github))
             url = "https://api.github.com/repos/{organisation}/{model_id}/zipball{suffix}".format(


### PR DESCRIPTION
  github: "local: /path/to/repository"
  github: "copy: /path/to/parentfolder"

This is currently in the form of an ugly hack, but I found the workflow it supports to be very convenient.
I thinks it would be straightforward to clean up the implmentation.

Local repository clone
```
                # Using
                #  github: "local: /path/to/repository"
                # in modeldb-run.yaml implies that we 'git clone /path/to/repos$
                # This is useful to tentatively explore the effect of
                # model changes on results with different nrn versions
                # without committing to github or before being ready to
                # make a pull request
```
and even more convenient is a local repository copy
``` 
               # Using
                #  github: "copy: /path/to/parentfolder"
                # in modeldb-run.yaml implies that we
                #  'cp -R /path/to/parentfolder/<id> <workingdir>'
                # A copy differs from a clone in that local changes in
                # the checkout are mirrored in the copy without having to
                # be committed. Note the copy leaves out the .git and
                # x86_64 folders.
```
though I haven't yet bothered to leave out the .git or x86_64 folders

One improvment might be to specify a list of ids in a separate yaml file with a format like
```
id:
  clone:  /path/to/parent/where/id/is/located
id:
  copy: /path/to/parent/where/id/is/located
```
in order to avoid temporary changes to modeldb/modeldb-run.yaml

I found the copy to be more useful than the clone so copy alone would suffice. In fact it would probably suffice merely to have an environment variable  like
```
export MODELDB_LOCAL_REPOSITORIES=$HOME/models/modeldb
```
and any id folder at that location that matches an id specified in getmodels or runmodels is copied from there
