### PR TITLE
Add .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+cache
+modeldb/modeldb-meta.yaml


### PR DESCRIPTION
Sometimes the current dir becomes a bit cluttered, and `git clean -df` sometimes removes too much (namely the `cache` dir and the `modeldb-meta.yaml` file), so adding a `.gitignore` with those 2 allows for easier cleanup of the project dir. Note that we can remove those as well using `git clean -xdf`.