### PR TITLE
Explictly specify numpy version

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -16,6 +16,7 @@ install_requires = [
     "matplotlib",
     "scipy",
     "2to3",
+    "numpy<2",
 ]
 
 with open("README.md", "r", encoding="utf-8") as f:


### PR DESCRIPTION
Part of the NumPy 2 workarounds.

MODELS_TO_RUN=187604