### PR TITLE
Pin pip to version <=24.0

### DIFF
--- a/.github/workflows/nrn-modeldb-ci.yaml
+++ b/.github/workflows/nrn-modeldb-ci.yaml
@@ -134,7 +134,7 @@ jobs:
         sudo apt-get install xvfb
         sudo /usr/bin/Xvfb $DISPLAY -screen 0 1600x1200x24 -noreset -nolock -shmem &  # run in bg
         # Install python dependencies
-        python -m pip install --upgrade pip
+        python -m pip install --upgrade 'pip<=24.0'
         if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
         #Install project in editable mode
         python -m pip install -e .


### PR DESCRIPTION
Due to stricter version parsing (introduced in [this commit](https://github.com/pypa/pip/commit/47a8480065d4eac252edb3673cfaecccb7dbf3c2)), newer versions of pip fail to uninstall versions of NEURON like `9.0a-294-g21ea378fd`.
Should fix https://github.com/neuronsimulator/nrn/issues/2969