### PR TITLE
Skip models that do not compile

### DIFF
--- a/modeldb/modeldb-run.yaml
+++ b/modeldb/modeldb-run.yaml
@@ -1880,3 +1880,9 @@
     github: 'pull/2'
 33728:
     github: 'pull/1'
+2014832:
+  skip: true
+  comment: ".mod files do not compile"
+2017405:
+  skip: true
+  comment: ".mod files do not compile"


### PR DESCRIPTION
Skip these models for now to keep the CI green:
- 2014832
- 2017405