### PR TITLE
Skip model 2016138

### DIFF
--- a/modeldb/modeldb-run.yaml
+++ b/modeldb/modeldb-run.yaml
@@ -1886,3 +1886,6 @@
 2017405:
   skip: true
   comment: ".mod files do not compile"
+2016138:
+  skip: true
+  comment: ".mod files do not compile with NEURON 9.0"


### PR DESCRIPTION
- 2016138 does not compile on NEURON 9.0