### PR TITLE
Fixes for RNG, part 3

### DIFF
--- a/modeldb/modeldb-run.yaml
+++ b/modeldb/modeldb-run.yaml
@@ -566,7 +566,6 @@
     - reg_20()
     - verify_graph_()
 82784:
-    github: 'pull/1'
     run:
     - load_file("runShort.hoc")
     - verify_graph_()
@@ -877,7 +876,6 @@
     - run()
     - verify_graph_()
 113732:
-    github: 'pull/1'
     run:
     - use_mcell_ran4(1)
     - suprathresh()
@@ -1310,7 +1308,7 @@
 150239:
     model_dir: nrn/mod
 150245:
-    github: "pull/5"
+    github: "pull/4"
     curate_patterns:
       - pattern: 't=100\.00;176\([0-9]+\.[0-9]+\)'
         repl: 't=100.00;176(%some_kind_of_clock%)'

--- a/modeldb/modeldb-run.yaml
+++ b/modeldb/modeldb-run.yaml
@@ -287,6 +287,7 @@
     - restart("demo_ampa")
     - verify_graph_()
 18502:
+    github: 'pull/1'
     run:
     - restart("ltp_two")
     - verify_graph_()
@@ -565,6 +566,7 @@
     - reg_20()
     - verify_graph_()
 82784:
+    github: 'pull/1'
     run:
     - load_file("runShort.hoc")
     - verify_graph_()
@@ -875,6 +877,7 @@
     - run()
     - verify_graph_()
 113732:
+    github: 'pull/1'
     run:
     - use_mcell_ran4(1)
     - suprathresh()
@@ -1158,7 +1161,7 @@
     - verify_graph_()
     model_dir: OneDimension/Neuron
 138379:
-    github: "pull/3"
+    github: "pull/4"
     curate_patterns:
       - pattern: 't=100\.00;(\d+)\([0-9.\-e]+\)'
         repl: 't=100.00;\1(%some_kind_of_clock%)'
@@ -1258,7 +1261,7 @@
       - pattern: 'Current time: .*'
         repl: 'Current time: %current_time%'
 146949:
-    github: "pull/4"
+    github: "pull/5"
     curate_patterns:
     - pattern: 't=([0-9\.]+);(\d+)\([0-9.\-e]+\)'
       repl: 't=\1;\2(%some_kind_of_clock%)'
@@ -1307,7 +1310,7 @@
 150239:
     model_dir: nrn/mod
 150245:
-    github: "pull/4"
+    github: "pull/5"
     curate_patterns:
       - pattern: 't=100\.00;176\([0-9]+\.[0-9]+\)'
         repl: 't=100.00;176(%some_kind_of_clock%)'
@@ -1435,7 +1438,7 @@
     skip: true
     comment: takes too long, need to see how to reduce time
 229276:
-    github: 'pull/3'
+    github: 'pull/4'
     model_dir: mechanisms
     script:
     - mkdir hoc_recordings


### PR DESCRIPTION
MODELS_TO_RUN=138379 229276 146949

Links to PRs:
- https://github.com/ModelDBRepository/18502/pull/1
- https://github.com/ModelDBRepository/138379/pull/4
- https://github.com/ModelDBRepository/229276/pull/4
- https://github.com/ModelDBRepository/146949/pull/5

Note that the CI fails, but this is because 8.2.6 on PyPI doesn't have the `TABLE` fix; if we apply the fix, it passes: https://github.com/neuronsimulator/nrn-modeldb-ci/actions/runs/11821925920/job/32937782329